### PR TITLE
Automated upload to https://explorer.helixmain.net

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - run: npm install
     - run: npm run build
 
-	- name: Upload build result
+    - name: Upload build result
       uses: actions/upload-artifact@v2
       with:
         name: dist

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: dist
-    - run: ls -al
+        path: dist
     - run: aws s3 sync dist s3://explorer.helixmain.net/
       env: # Or as an environment variable
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -38,6 +38,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: dist
+    - run: ls -al
     - run: aws s3 sync dist s3://explorer.helixmain.net/
       env: # Or as an environment variable
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,8 +25,8 @@ jobs:
     - run: npm install
     - run: npm run build
 
-	 - name: Upload build result
-        uses: actions/upload-artifact@v1
-        with:
-          name: dist
-          path: dist
+	- name: Upload build result
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist/

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -30,3 +30,16 @@ jobs:
       with:
         name: dist
         path: dist/
+  upload:
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download build result
+      uses: actions/download-artifact@v2
+      with:
+        name: dist
+    - run: aws s3 sync dist s3://explorer.helixmain.net/
+      env: # Or as an environment variable
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -31,7 +31,7 @@ jobs:
         name: dist
         path: dist/
   upload:
-
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - name: Download build result

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -24,3 +24,9 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm run build
+
+	 - name: Upload build result
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,26 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: build and publish
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build


### PR DESCRIPTION
Hello,

I'm helping @dzhelezov to setup the instance of pendulum-explorer on https://explorer.helixmain.net.

Setup is simple: static website via AWS S3.

Infrastructure is the ready and initial version of code uploaded to the S3 bucket.

This PR automates the upload of distribution to the S3 bucket.

NOTE: please set 3 [GitHub Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) to make upload work:
* AWS_ACCESS_KEY_ID
* AWS_SECRET_ACCESS_KEY
* AWS_DEFAULT_REGION

@dzhelezov or I can provide values.
